### PR TITLE
fix: remote create new file

### DIFF
--- a/ollama/_client.py
+++ b/ollama/_client.py
@@ -262,7 +262,7 @@ class Client(BaseClient):
     for line in io.StringIO(modelfile):
       command, _, args = line.partition(' ')
       if command.upper() in ['FROM', 'ADAPTER']:
-        path = Path(args).expanduser()
+        path = Path(args.strip()).expanduser()
         path = path if path.is_absolute() else base / path
         if path.exists():
           args = f'@{self._create_blob(path)}'
@@ -288,7 +288,7 @@ class Client(BaseClient):
         raise
 
       with open(path, 'rb') as r:
-        self._request('PUT', f'/api/blobs/{digest}', content=r)
+        self._request('POST', f'/api/blobs/{digest}', content=r)
 
     return digest
 

--- a/ollama/_client.py
+++ b/ollama/_client.py
@@ -563,7 +563,7 @@ class AsyncClient(BaseClient):
               break
             yield chunk
 
-      await self._request('PUT', f'/api/blobs/{digest}', content=upload_bytes())
+      await self._request('POST', f'/api/blobs/{digest}', content=upload_bytes())
 
     return digest
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -418,7 +418,7 @@ def test_client_create_from_library(httpserver: HTTPServer):
 
 def test_client_create_blob(httpserver: HTTPServer):
   httpserver.expect_ordered_request(PrefixPattern('/api/blobs/'), method='HEAD').respond_with_response(Response(status=404))
-  httpserver.expect_ordered_request(PrefixPattern('/api/blobs/'), method='PUT').respond_with_response(Response(status=201))
+  httpserver.expect_ordered_request(PrefixPattern('/api/blobs/'), method='POST').respond_with_response(Response(status=201))
 
   client = Client(httpserver.url_for('/'))
 
@@ -759,7 +759,7 @@ async def test_async_client_create_from_library(httpserver: HTTPServer):
 @pytest.mark.asyncio
 async def test_async_client_create_blob(httpserver: HTTPServer):
   httpserver.expect_ordered_request(PrefixPattern('/api/blobs/'), method='HEAD').respond_with_response(Response(status=404))
-  httpserver.expect_ordered_request(PrefixPattern('/api/blobs/'), method='PUT').respond_with_response(Response(status=201))
+  httpserver.expect_ordered_request(PrefixPattern('/api/blobs/'), method='POST').respond_with_response(Response(status=201))
 
   client = AsyncClient(httpserver.url_for('/'))
 


### PR DESCRIPTION
Just noticed this while working on the `ollama-js` library, two bugs.
- A new-line in the Modelfile causes `path.exists()` to not be true.
- The blob creation endpoint is `POST` rather than `PUT`

Example Modelfile:
```
FROM ~/models/nous-capybara/nous-capybara-34b.Q4_0.gguf
TEMPLATE "USER: { .Prompt } ASSISTANT: "
```