### PR TITLE
Changed 'show' to use POST instead of GET

### DIFF
--- a/ollama/_client.py
+++ b/ollama/_client.py
@@ -304,7 +304,7 @@ class Client(BaseClient):
     return {'status': 'success' if response.status_code == 200 else 'error'}
 
   def show(self, model: str) -> Mapping[str, Any]:
-    return self._request('GET', '/api/show', json={'name': model}).json()
+    return self._request('POST', '/api/show', json={'name': model}).json()
 
 
 class AsyncClient(BaseClient):
@@ -580,7 +580,7 @@ class AsyncClient(BaseClient):
     return {'status': 'success' if response.status_code == 200 else 'error'}
 
   async def show(self, model: str) -> Mapping[str, Any]:
-    response = await self._request('GET', '/api/show', json={'name': model})
+    response = await self._request('POST', '/api/show', json={'name': model})
     return response.json()
 
 


### PR DESCRIPTION
ollama.show failed:

```
---------------------------------------------------------------------------
ResponseError                             Traceback (most recent call last)
Cell In[9], line 1
----> 1 ollama.show(model = "zephyr:latest")

File ~/miniforge3/envs/ollama/lib/python3.11/site-packages/ollama/_client.py:307, in Client.show(self, model)
    306 def show(self, model: str) -> Mapping[str, Any]:
--> 307   return self._request('GET', '/api/show', json={'name': model}).json()

File ~/miniforge3/envs/ollama/lib/python3.11/site-packages/ollama/_client.py:59, in Client._request(self, method, url, **kwargs)
     57   response.raise_for_status()
     58 except httpx.HTTPStatusError as e:
---> 59   raise ResponseError(e.response.text, e.response.status_code) from None
     61 return response

ResponseError: 404 page not found
```

Fixed by changed method from GET to POST.