### PR TITLE
ci: give publish job content perms

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,6 +11,7 @@ jobs:
     environment: release
     permissions:
       id-token: write
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - run: pipx install poetry


### PR DESCRIPTION
[`contents: write`](https://docs.github.com/en/rest/authentication/permissions-required-for-github-apps?apiVersion=2022-11-28#repository-permissions-for-contents) is required for [asset upload](https://docs.github.com/en/rest/releases/assets?apiVersion=2022-11-28#upload-a-release-asset)