### PR TITLE
add example for pulling with progress bar

### DIFF
--- a/examples/pull-stream-progress/main.py
+++ b/examples/pull-stream-progress/main.py
@@ -1,0 +1,23 @@
+# pip install tqdm
+
+from tqdm import tqdm
+from ollama import pull
+
+
+current_digest, bars = '', {}
+for progress in pull('mistral', stream=True):
+  digest = progress.get('digest', '')
+  if digest != current_digest and current_digest in bars:
+    bars[current_digest].close()
+
+  if not digest:
+    print(progress.get('status'))
+    continue
+
+  if digest not in bars and (total := progress.get('total')):
+    bars[digest] = tqdm(total=total, desc=f'pushing {digest[7:19]}', unit='B', unit_scale=True)
+
+  if completed := progress.get('completed'):
+    bars[digest].update(completed - bars[digest].n)
+
+  current_digest = digest


### PR DESCRIPTION
```
$ pip install ollama tqdm
$ python examples/pull-stream-progress/main.py
pulling manifest
pushing e8a35b5937a5: 100%|████████████████████████████████████████████████████████| 4.11G/4.11G [00:00<00:00, 17.5TB/s]
pushing 43070e2d4e53: 100%|████████████████████████████████████████████████████████| 11.4k/11.4k [00:00<00:00, 86.1MB/s]
pushing e6836092461f: 100%|███████████████████████████████████████████████████████████| 42.0/42.0 [00:00<00:00, 790kB/s]
pushing ed11eda7790d: 100%|███████████████████████████████████████████████████████████| 30.0/30.0 [00:00<00:00, 567kB/s]
pushing f9b1e3196ecf: 100%|████████████████████████████████████████████████████████████| 483/483 [00:00<00:00, 12.3MB/s]
verifying sha256 digest
writing manifest
removing any unused layers
success
```